### PR TITLE
Fix the "Dry run" option

### DIFF
--- a/src/cleaner.php
+++ b/src/cleaner.php
@@ -51,7 +51,7 @@ try {
         foreach ($attachments as $attachment) {
             echo '    ID: ' . $attachment->getId() . ' (' . $attachment->getName() . ')';
             if (!$pattern || preg_match('/' . $pattern . '/', $attachment->getName())) {
-                if ($dryRun) {
+                if (!$dryRun) {
                     $success = $youtrack->deleteAttachment($issue, $attachment);
                     if ($success) {
                         echo ' deleted';


### PR DESCRIPTION
At this moment the script deletes files WITH -d option and does a test run WITHOUT this option. It should be the other way.
